### PR TITLE
Use multiple strategies for detecting ghc mismatches

### DIFF
--- a/ghc-check.cabal
+++ b/ghc-check.cabal
@@ -19,6 +19,7 @@ library
   other-modules:
                        GHC.Check.Util
   build-depends:       base >=4.10.0.0 && < 5.0,
+                       containers,
                        directory,
                        filepath,
                        ghc,

--- a/src/GHC/Check.hs
+++ b/src/GHC/Check.hs
@@ -1,33 +1,131 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+
 module GHC.Check
-( VersionCheck(..)
-, makeGhcVersionChecker
-, checkGhcVersion
-) where
+  ( GhcVersionChecker,
+    InstallationCheck(..),
+    PackageCheck,
+    PackageMismatch (..),
+    makeGhcVersionChecker,
+    checkGhcVersion,
+  )
+where
 
-import           Control.Exception
-import           Data.Maybe
-import           Data.Version               (Version)
-import           GHC
-import           GHC.Check.Executable (getGhcVersion, guessExecutablePathFromLibdir)
-import           GHC.Check.PackageDb  (getPackageVersionIO)
-import           GHC.Check.Util       (liftVersion, guessLibdir)
-import           Language.Haskell.TH
-import           Language.Haskell.TH.Syntax
+import Control.Exception
 import Control.Monad (filterM)
-import System.Directory (doesFileExist)
+import Data.Function (on)
+import Data.List (intersectBy)
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Strict as Map
+import Data.Maybe
+import Data.Monoid (First (First), getFirst)
+import Data.Version (Version)
+import GHC (Ghc, getSessionDynFlags, runGhc, setSessionDynFlags)
+import GHC.Check.Executable (getGhcVersion, guessExecutablePathFromLibdir)
+import GHC.Check.PackageDb (PackageVersion (..), getPackageVersion, version)
+import GHC.Check.Util (liftTyped)
+import Language.Haskell.TH (TExpQ, runIO)
+import Language.Haskell.TH.Syntax (Lift (lift))
+import System.Directory (doesFileExist)
 
-data VersionCheck
-    = Match
-    | Mismatch { compileTime :: !Version
-               , runTime     :: !Version
-               }
-    | Failure String
-    deriving (Eq, Show)
+-- | Given a run-time libdir, checks the ghc installation and returns
+--   a 'Ghc' action to check the package database
+type GhcVersionChecker = String -> IO InstallationCheck
 
--- | A GHC version retrieved from the ghc executable
+data InstallationCheck
+  = InstallationChecked (Ghc PackageCheck)
+  | InstallationMismatch { compileTime, runTime :: !Version}
+
+type PackageCheck = Maybe (String, PackageMismatch)
+
+data PackageMismatch
+  = VersionMismatch { compileTime, runTime :: !Version }
+  | AbiMismatch { compileTimeAbi, runTimeAbi :: !String }
+  deriving (Eq, Show)
+
+comparePackageVersions :: PackageVersion -> PackageVersion -> Maybe PackageMismatch
+comparePackageVersions compile run
+  | compile == run = Nothing
+  | abi compile == abi run =
+    Just $ VersionMismatch (version compile) (version run)
+  | otherwise =
+    Just $ AbiMismatch (abi compile) (abi run)
+
+collectPackageVersions :: [String] -> Ghc [(String, PackageVersion)]
+collectPackageVersions =
+  fmap catMaybes . mapM (\p -> fmap (p,) <$> getPackageVersion p)
+
+-- | Checks if the run-time version of the @ghc@ package matches the given version.
+checkGhcVersion ::
+  [String] ->
+  [(String, PackageVersion)] ->
+  GhcVersionChecker
+checkGhcVersion trackedPackages compileTimeVersions runTimeLibdir = do
+  let compileTimeVersionsMap = Map.fromList compileTimeVersions
+      compileTime = version $ compileTimeVersionsMap Map.! "ghc"
+
+  runTime <- ghcRunTimeVersion runTimeLibdir
+
+  return $ if runTime /= compileTime
+    then InstallationMismatch{..}
+    else InstallationChecked $ do
+      runTimeVersions <- collectPackageVersions trackedPackages
+      let compares =
+            Map.intersectionWith
+              comparePackageVersions
+              compileTimeVersionsMap
+              (Map.fromList runTimeVersions)
+          mismatches = Map.mapMaybe id compares
+
+      return
+        $ getFirst
+        $ foldMap
+          (\p -> First $ (p,) <$> Map.lookup p mismatches)
+          trackedPackages
+
+-- | @makeGhcVersionChecker libdir@ returns a function to check the run-time
+--   version of ghc against the compile-time version. It performs two checks:
+--
+--     1. It checks the version of the ghc installation given the run-time libdir
+--        In some platforms, like Nix, the libdir is not fixed at compile-time
+--
+--     2. It compares the version of the 'ghc' package, if found at run-time.
+--        If not, it compares the 'abi' of the 'base' package.
+--
+--    > ghcChecker :: IO(Ghc (String -> PackageCheck))
+--    > ghcChecker = $$(makeGhcVersionChecker (pure $ Just GHC.Paths.libdir))
+--    >
+--    > checkGhcVersion :: IO ()
+--    > checkGhcVersion = do
+--    >     InstallationChecked ghcLibVersionChecker <- ghcChecker runTimeLibdir
+--    >     res <- runGhc (Just runTimeLibdir) $ do
+--    >              setupGhcApi
+--    >              Right Nothing <- gtry ghcLibVersionChecker
+--    >              doSomethingInteresting
+
+makeGhcVersionChecker :: IO FilePath -> TExpQ GhcVersionChecker
+makeGhcVersionChecker getLibdir = do
+  libdir <- runIO getLibdir
+  compileTimeVersions <-
+    runIO
+      $ runGhcPkg libdir
+      $ collectPackageVersions trackedPackages
+  [||checkGhcVersion trackedPackages $$(liftTyped compileTimeVersions)||]
+  where
+    trackedPackages = ["ghc", "base"]
+
+runGhcPkg :: FilePath -> Ghc a -> IO a
+runGhcPkg libdir action = runGhc (Just libdir) $ do
+  -- initialize the Ghc session
+  -- there's probably a better way to do this.
+  dflags <- getSessionDynFlags
+  _ <- setSessionDynFlags dflags
+  action
+
+-- | A GHC version retrieved from the ghc installation in the given libdir
 ghcRunTimeVersion :: String -> IO Version
 ghcRunTimeVersion libdir = do
     let guesses = guessExecutablePathFromLibdir libdir
@@ -35,35 +133,3 @@ ghcRunTimeVersion libdir = do
     case validGuesses of
         firstGuess:_ -> getGhcVersion firstGuess
         [] -> fail $ "Unable to find the GHC executable for libdir: " <> libdir
-
--- | Checks if the run-time version of the @ghc@ package matches the given version.
-checkGhcVersion :: Version -> String -> IO VersionCheck
-checkGhcVersion expectedVersion libdir = handleErrors $ do
-    v <- ghcRunTimeVersion libdir
-    return $ if v == expectedVersion
-                then GHC.Check.Match
-                else Mismatch expectedVersion v
-    where
-        handleErrors = flip catches
-            [Handler (throwIO @SomeAsyncException)
-            ,Handler (pure . Failure . show @SomeException)
-            ]
-
--- | @makeGhcVersionChecker libdir@ returns a function to check the run-time
---   version of ghc against the compile-time version, given the run-time GHC libdir.
---
---    > ghcVersionChecker :: FilePath -> IO VersionCheck
---    > ghcVersionChecker = $$(makeGhcVersionChecker (pure $ Just GHC.Paths.libdir))
---    >
---    > checkGhcVersion :: IO ()
---    > checkGhcVersion = do
---    >     res <- ghcVersionChecker GHC.Paths.libdir
---    >     print res
---
-makeGhcVersionChecker :: IO (Maybe FilePath) -> TExpQ (FilePath -> IO VersionCheck)
-makeGhcVersionChecker getLibdir = do
-    libdir <- runIO $ maybe guessLibdir return =<< getLibdir
-    compileTimeVersion <- runIO $ do
-        mbVersion <- getPackageVersionIO libdir "ghc"
-        return $ fromMaybe (error "unreachable - the ghc package is a Cabal dependency") mbVersion
-    [|| checkGhcVersion $$(liftVersion compileTimeVersion) ||]

--- a/src/GHC/Check.hs
+++ b/src/GHC/Check.hs
@@ -49,10 +49,10 @@ data PackageMismatch
 comparePackageVersions :: PackageVersion -> PackageVersion -> Maybe PackageMismatch
 comparePackageVersions compile run
   | compile == run = Nothing
-  | abi compile == abi run =
-    Just $ VersionMismatch (version compile) (version run)
-  | otherwise =
+  | version compile == version run =
     Just $ AbiMismatch (abi compile) (abi run)
+  | otherwise =
+    Just $ VersionMismatch (version compile) (version run)
 
 collectPackageVersions :: [String] -> Ghc [(String, PackageVersion)]
 collectPackageVersions =

--- a/src/GHC/Check/PackageDb.hs
+++ b/src/GHC/Check/PackageDb.hs
@@ -1,41 +1,57 @@
+{-# LANGUAGE DeriveLift #-}
+-- | Discover the GHC version via the package database. Requirements:
+--
+--     * the package database must be compatible, which is usually not the case
+--       across major ghc versions.
+--
+--     * the 'ghc' package is registered, which is not always the case.
+module GHC.Check.PackageDb
+  ( PackageVersion(abi), version,
+    getPackageVersion,
+  )
+where
 
-{- | Discover the GHC version via the package database. Requirements:
+import Control.Monad.Trans.Class as Monad (MonadTrans (lift))
+import Data.Maybe (fromMaybe)
+import Data.String (IsString (fromString))
+import Data.Version (Version)
+import GHC
+  ( Ghc,
+    getSessionDynFlags,
+    runGhc,
+    setSessionDynFlags,
+  )
+import GHC.Check.Util
+import GHC.Exts (IsList (fromList), toList)
+import Maybes (MaybeT (MaybeT), runMaybeT)
+import Module (componentIdToInstalledUnitId)
+import PackageConfig (PackageName (PackageName))
+import Packages
+  ( lookupInstalledPackage,
+    lookupPackageName,
+  )
+import Packages (InstalledPackageInfo (..))
+import Packages (PackageConfig)
+import Language.Haskell.TH.Syntax (Lift)
+import Language.Haskell.TH (TExpQ)
 
-     * the package database must be compatible, which is usually not the case
-       across major ghc versions.
+data PackageVersion
+  = PackageVersion
+      { myVersion :: !MyVersion,
+        abi :: !String
+      }
+  deriving (Eq, Lift, Show)
 
-     * the 'ghc' package is registered, which is not always the case.
- -}
-module GHC.Check.PackageDb where
+version :: PackageVersion -> Version
+version PackageVersion{ myVersion = MyVersion v} = v
 
-import           Control.Monad.Trans.Class as Monad (MonadTrans (lift))
-import           Data.Maybe                (fromMaybe)
-import           Data.String               (IsString (fromString))
-import           Data.Version              (Version)
-import           GHC                       (setSessionDynFlags, runGhc, getSessionDynFlags, Ghc)
-import           GHC.Exts                  (IsList (fromList), toList)
-import           Maybes                    (MaybeT (MaybeT), runMaybeT)
-import           Module                    (componentIdToInstalledUnitId)
-import           PackageConfig             (PackageName (PackageName))
-import           Packages                  (lookupInstalledPackage, lookupPackageName)
-import           Packages                  (InstalledPackageInfo (packageVersion))
-
--- | @getPackageVersion p@ returns the version of package @p@ in
---     the package database
-getPackageVersion :: String -> Ghc (Maybe Version)
+-- | @getPackageVersion p@ returns the version of package @p@ in the package database
+getPackageVersion :: String -> Ghc (Maybe PackageVersion)
 getPackageVersion packageName = runMaybeT $ do
-    dflags <- Monad.lift getSessionDynFlags
-    component <- MaybeT $ return $ lookupPackageName dflags $ PackageName $ fromString packageName
-    p <- MaybeT $ return $ lookupInstalledPackage dflags (componentIdToInstalledUnitId component)
-    return $ packageVersion p
+  dflags <- Monad.lift getSessionDynFlags
+  component <- MaybeT $ return $ lookupPackageName dflags $ PackageName $ fromString packageName
+  p <- MaybeT $ return $ lookupInstalledPackage dflags (componentIdToInstalledUnitId component)
+  return $ mkPackageVersion p
 
--- | @getPackageVersionIO ghc-libdir p@ returns the version of package @p@
---   in the default package database
-getPackageVersionIO :: FilePath -> String -> IO (Maybe Version)
-getPackageVersionIO libdir package = runGhc (Just libdir) $ do
-    -- initialize the Ghc session
-    -- there's probably a beteter way to do this.
-    dflags <- getSessionDynFlags
-    _ <- setSessionDynFlags dflags
-
-    getPackageVersion package
+mkPackageVersion :: PackageConfig -> PackageVersion
+mkPackageVersion p = PackageVersion (MyVersion $ packageVersion p) (abiHash p)


### PR DESCRIPTION
Check the runtime ghc installation,
the runtime ghc package version,
and the base package abi version

Fixes #6 