### PR TITLE
Add support for GHC-9.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,20 @@ jobs:
         cabal: ["3.2"]
         ghc:
           - "8.6.5"
-          - "8.8.3"
-          - "8.10.1"
+          - "8.8.4"
+          - "8.10.4"
+          - "9.0.1"
         exclude:
           - os: macOS-latest
-            ghc: 8.8.3
+            ghc: 9.0.1
+          - os: macOS-latest
+            ghc: 8.8.4
           - os: macOS-latest
             ghc: 8.6.5
           - os: windows-latest
-            ghc: 8.8.3
+            ghc: 9.0.1
+          - os: windows-latest
+            ghc: 8.8.4
           - os: windows-latest
             ghc: 8.6.5
 
@@ -33,7 +38,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -61,13 +66,13 @@ jobs:
     strategy:
       matrix:
         stack: ["2.1.3"]
-        ghc: ["8.8.3"]
+        ghc: ["8.8.4"]
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.2"]
+        cabal: ["3.4"]
         ghc:
           - "8.6.5"
           - "8.8.4"
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.1.3"]
+        stack: ["2.5.1"]
         ghc: ["8.8.4"]
 
     steps:
@@ -83,6 +83,10 @@ jobs:
       with:
         path: ~/.stack
         key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+
+    - name: Stack init
+      run: |
+        stack init --system-ghc
 
     - name: Build
       run: |

--- a/ghc-check.cabal
+++ b/ghc-check.cabal
@@ -32,6 +32,7 @@ library
                        process,
                        safe-exceptions,
                        template-haskell,
+                       th-compat >= 0.1.2,
                        transformers
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/ghc-check.cabal
+++ b/ghc-check.cabal
@@ -35,6 +35,7 @@ library
                        th-compat >= 0.1.2,
                        transformers
   hs-source-dirs:      src
+  ghc-options:         -Wall
   default-language:    Haskell2010
   if flag(ghc-check-use-package-abis)
     cpp-options: -DUSE_PACKAGE_ABIS

--- a/src/GHC/Check.hs
+++ b/src/GHC/Check.hs
@@ -37,7 +37,8 @@ import GHC (Ghc)
 import GHC.Check.Executable (getGhcVersion, guessExecutablePathFromLibdir)
 import GHC.Check.PackageDb (fromVersionString, PackageVersion (..), getPackageVersion, version)
 import GHC.Check.Util (gcatchSafe, liftTyped)
-import Language.Haskell.TH (TExpQ, runIO)
+import Language.Haskell.TH as TH (TExpQ, runIO)
+import qualified Language.Haskell.TH as TH
 import System.Directory (doesDirectoryExist, doesFileExist)
 
 #if USE_PACKAGE_ABIS
@@ -153,7 +154,11 @@ checkGhcVersion compileTimeVersions runTimeLibdir = do
 makeGhcVersionChecker :: IO FilePath -> TExpQ GhcVersionChecker
 makeGhcVersionChecker getLibdir = do
   compileTimeVersions <- runIO $ compileTimeVersions getLibdir
+#if MIN_VERSION_template_haskell(2,17,0)
+  TH.examineCode [||checkGhcVersion $$(liftTyped compileTimeVersions)||]
+#else
   [||checkGhcVersion $$(liftTyped compileTimeVersions)||]
+#endif
 
 compileTimeVersions :: IO FilePath -> IO [(String, PackageVersion)]
 compileTimeVersions getLibdir = do

--- a/src/GHC/Check.hs
+++ b/src/GHC/Check.hs
@@ -37,7 +37,6 @@ import GHC (Ghc)
 import GHC.Check.Executable (getGhcVersion, guessExecutablePathFromLibdir)
 import GHC.Check.PackageDb (fromVersionString, PackageVersion (..), getPackageVersion, version)
 import GHC.Check.Util (gcatchSafe, liftTyped)
-import Language.Haskell.TH as TH (TExpQ, runIO)
 import qualified Language.Haskell.TH as TH
 import System.Directory (doesDirectoryExist, doesFileExist)
 
@@ -151,13 +150,22 @@ checkGhcVersion compileTimeVersions runTimeLibdir = do
 --    >              setupGhcApi
 --    >              result <- packageCheck
 --    >              case guessCompatibility result of ...
-makeGhcVersionChecker :: IO FilePath -> TExpQ GhcVersionChecker
-makeGhcVersionChecker getLibdir = do
-  compileTimeVersions <- runIO $ compileTimeVersions getLibdir
+makeGhcVersionChecker :: IO FilePath -> CodeQ GhcVersionChecker
+makeGhcVersionChecker getLibdir = liftCode $ do
+  compileTimeVersions <- TH.runIO $ compileTimeVersions getLibdir
+  examineCode [||checkGhcVersion $$(liftTyped compileTimeVersions)||]
+
+-- Compatability layer
+liftCode :: TH.TExpQ a -> CodeQ a
+examineCode :: CodeQ a -> TH.TExpQ a
 #if MIN_VERSION_template_haskell(2,17,0)
-  TH.examineCode [||checkGhcVersion $$(liftTyped compileTimeVersions)||]
+type CodeQ = TH.CodeQ
+liftCode = TH.liftCode
+examineCode = TH.examineCode
 #else
-  [||checkGhcVersion $$(liftTyped compileTimeVersions)||]
+type CodeQ x = TH.TExpQ x
+liftCode = id
+examineCode = id
 #endif
 
 compileTimeVersions :: IO FilePath -> IO [(String, PackageVersion)]

--- a/src/GHC/Check/PackageDb.hs
+++ b/src/GHC/Check/PackageDb.hs
@@ -26,19 +26,12 @@ import GHC
     getSessionDynFlags,
   )
 import GHC.Data.Maybe (MaybeT (MaybeT), runMaybeT)
--- import GHC.Unit.Module (toUnitId)
 import GHC.Unit.Info (PackageName (PackageName))
 import GHC.Unit.State
   (lookupUnit, explicitUnits,  lookupUnitId,
-    lookupPackageName
-  )
-import GHC.Unit.State (GenericUnitInfo (..))
-import GHC.Unit.State (UnitInfo)
-import GHC.Unit.State (unitPackageNameString)
+    lookupPackageName, GenericUnitInfo (..), 
+    UnitInfo, unitPackageNameString)
 import GHC.Unit.Types (indefUnit)
--- import GHC.Unit.Types (Unit, UnitId)
--- import GHC.Driver.Session (DynFlags)
--- import GHC.Unit.State (UnitState)
 #else
 import GHC
   (pkgState,  Ghc,

--- a/src/GHC/Check/PackageDb.hs
+++ b/src/GHC/Check/PackageDb.hs
@@ -51,7 +51,7 @@ import Packages
   (lookupPackage, explicitPackages,  lookupInstalledPackage,
     lookupPackageName
   )
-import Packages (InstalledPackageInfo (..))
+import Packages (InstalledPackageInfo (packageVersion, abiHash))
 import Packages (PackageConfig)
 import Packages (packageNameString)
 #endif

--- a/src/GHC/Check/Util.hs
+++ b/src/GHC/Check/Util.hs
@@ -4,10 +4,11 @@
 {-# LANGUAGE CPP, TemplateHaskell #-}
 module GHC.Check.Util (MyVersion(..), liftTyped, gcatchSafe) where
 
-import           Control.Exception.Safe
+import           Control.Exception.Safe as Safe
 import           Control.Monad.IO.Class (MonadIO(liftIO))
 import           Data.Version ( Version, parseVersion )
-import           GHC (Ghc, gcatch)
+import           GHC (Ghc)
+import qualified GHC
 import           GHC.Exts                   (IsList (fromList), toList)
 import           Language.Haskell.TH ( TExpQ )
 import           Language.Haskell.TH.Syntax as TH
@@ -20,16 +21,25 @@ newtype MyVersion = MyVersion Version
 instance Lift MyVersion where
 #if MIN_VERSION_template_haskell(2,16,0)
     liftTyped = liftMyVersion
-#endif
+#else
     lift = unTypeQ . liftMyVersion
+#endif
+    -- lift = unTypeCode . liftMyVersion
 
 instance Read MyVersion where
   readPrec = Read.lift $ MyVersion <$> parseVersion
 
+#if MIN_VERSION_template_haskell(2,17,0)
+liftMyVersion :: (Quote m) => MyVersion -> Code m MyVersion
+liftMyVersion ver = Code $ do
+    verLifted <- TH.lift (toList ver)
+    TH.examineCode [|| fromList $$( TH.Code . pure $ TExp verLifted)||]
+#else
 liftMyVersion :: MyVersion -> TExpQ MyVersion
 liftMyVersion ver = do
     verLifted <- TH.lift (toList ver)
     [|| fromList $$(pure $ TExp verLifted) ||]
+#endif
 
 #if !MIN_VERSION_template_haskell(2,16,0)
 liftTyped :: Lift a => a -> TExpQ a
@@ -37,9 +47,13 @@ liftTyped = unsafeTExpCoerce . lift
 #endif
 
 gcatchSafe :: forall e a . Exception e => Ghc a -> (e -> Ghc a) -> Ghc a
-gcatchSafe act h = act `gcatch` rethrowAsyncExceptions
+#if MIN_VERSION_ghc(9,0,1)
+gcatchSafe = Safe.catch
+#else
+gcatchSafe act h = act `GHC.gcatch` rethrowAsyncExceptions
   where
       rethrowAsyncExceptions :: e -> Ghc a
       rethrowAsyncExceptions e
         | isAsyncException e = liftIO . throwIO $ e
         | otherwise = h e
+#endif


### PR DESCRIPTION
Fixes #11

There is a bit of code duplication as a result of CPP pragmas for backwards compatibility that could probably be cleaned up. I hope that it's be fine, it can be cleaned up later if necessary.

Tested (compiled)  on GHC-8.8.4, GHC-8.10.4 and GHC-9.0.1

One more tiny step towards: https://github.com/haskell/haskell-language-server/issues/297